### PR TITLE
Add newsletter subscription with email forwarding

### DIFF
--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json();
+
+    if (typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+    }
+
+    const webhook = process.env.NEWSLETTER_WEBHOOK_URL;
+
+    if (webhook) {
+      const res = await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, source: "website" }),
+      });
+
+      if (!res.ok) {
+        return NextResponse.json({ error: "Failed to subscribe" }, { status: 502 });
+      }
+    } else {
+      console.log("Newsletter subscribe:", { email, ts: new Date().toISOString() });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import nodemailer from "nodemailer";
 
 export async function POST(req: NextRequest) {
   try {
@@ -8,24 +9,43 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid email" }, { status: 400 });
     }
 
-    const webhook = process.env.NEWSLETTER_WEBHOOK_URL;
+    const {
+      SMTP_HOST,
+      SMTP_PORT,
+      SMTP_USER,
+      SMTP_PASS,
+      FROM_EMAIL,
+      TO_EMAIL,
+      SMTP_SECURE,
+    } = process.env as Record<string, string | undefined>;
 
-    if (webhook) {
-      const res = await fetch(webhook, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, source: "website" }),
-      });
-
-      if (!res.ok) {
-        return NextResponse.json({ error: "Failed to subscribe" }, { status: 502 });
-      }
-    } else {
-      console.log("Newsletter subscribe:", { email, ts: new Date().toISOString() });
+    if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS || !FROM_EMAIL || !TO_EMAIL) {
+      return NextResponse.json({ error: "Email transport not configured" }, { status: 500 });
     }
+
+    const transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: Number(SMTP_PORT),
+      secure: SMTP_SECURE ? SMTP_SECURE === "true" : Number(SMTP_PORT) === 465,
+      auth: { user: SMTP_USER, pass: SMTP_PASS },
+    });
+
+    await transporter.verify();
+
+    const now = new Date().toISOString();
+
+    await transporter.sendMail({
+      from: FROM_EMAIL,
+      to: TO_EMAIL,
+      replyTo: email,
+      subject: "New newsletter subscriber",
+      text: `A new subscriber joined.\nEmail: ${email}\nTime: ${now}`,
+      html: `<p>A new subscriber joined.</p><p><b>Email:</b> ${email}</p><p><b>Time:</b> ${now}</p>`,
+    });
 
     return NextResponse.json({ ok: true });
   } catch (error) {
+    console.error("Newsletter error:", error);
     return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
   }
 }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -34,13 +34,8 @@ export default function NewsPage() {
       setStatus("error");
       setMessage("We couldn't subscribe you right now. Please try again later.");
     } catch (err) {
-      // Fallback to mailto if network error
-      const mailto = `mailto:info@example.com?subject=Newsletter%20Subscription&body=Please%20subscribe%20me%20with%20this%20email:%20${encodeURIComponent(
-        email
-      )}`;
-      window.location.href = mailto;
-      setStatus("success");
-      setMessage("Opening your email app to complete subscription.");
+      setStatus("error");
+      setMessage("We couldn't subscribe you right now. Please try again later.");
     }
   }
 

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function NewsPage() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [message, setMessage] = useState<string>("");
+
+  async function handleSubscribe(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setStatus("error");
+      setMessage("Enter a valid email address.");
+      return;
+    }
+    setStatus("loading");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/newsletter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+        setMessage("You're subscribed. Check your inbox for a confirmation email.");
+        setEmail("");
+        return;
+      }
+
+      // Fallback to mailto if server returns non-OK
+      const mailto = `mailto:info@example.com?subject=Newsletter%20Subscription&body=Please%20subscribe%20me%20with%20this%20email:%20${encodeURIComponent(
+        email
+      )}`;
+      window.location.href = mailto;
+      setStatus("success");
+      setMessage("Opening your email app to complete subscription.");
+    } catch (err) {
+      // Fallback to mailto if network error
+      const mailto = `mailto:info@example.com?subject=Newsletter%20Subscription&body=Please%20subscribe%20me%20with%20this%20email:%20${encodeURIComponent(
+        email
+      )}`;
+      window.location.href = mailto;
+      setStatus("success");
+      setMessage("Opening your email app to complete subscription.");
+    }
+  }
+
+  return (
+    <main className="min-h-screen pt-28 pb-20 px-6 flex items-start justify-center bg-black text-white">
+      <section className="w-full max-w-xl">
+        <h1 className="text-3xl sm:text-4xl font-semibold mb-6">Subscribe to our newsletter</h1>
+        <p className="text-white/80 mb-8">
+          Get updates on monasteries, events, and new features. No spam.
+        </p>
+        <form onSubmit={handleSubscribe} className="flex flex-col sm:flex-row gap-4">
+          <input
+            type="email"
+            inputMode="email"
+            placeholder="Enter your email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="flex-1 h-12 rounded-md bg-white/10 text-white placeholder:text-white/60 px-4 outline-none focus:ring-2 focus:ring-white/30 border border-white/10"
+            aria-label="Email address"
+            required
+          />
+          <Button type="submit" className="h-12 px-6 bg-white text-black hover:bg-white/90">
+            Subscribe
+          </Button>
+        </form>
+        {status !== "idle" && (
+          <p className={`mt-4 text-sm ${status === "error" ? "text-red-400" : "text-white/80"}`}>
+            {message}
+          </p>
+        )}
+        <div className="mt-10 text-xs text-white/60">
+          By subscribing, you agree to receive emails from us. You can unsubscribe at any time.
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -31,13 +31,8 @@ export default function NewsPage() {
         return;
       }
 
-      // Fallback to mailto if server returns non-OK
-      const mailto = `mailto:info@example.com?subject=Newsletter%20Subscription&body=Please%20subscribe%20me%20with%20this%20email:%20${encodeURIComponent(
-        email
-      )}`;
-      window.location.href = mailto;
-      setStatus("success");
-      setMessage("Opening your email app to complete subscription.");
+      setStatus("error");
+      setMessage("We couldn't subscribe you right now. Please try again later.");
     } catch (err) {
       // Fallback to mailto if network error
       const mailto = `mailto:info@example.com?subject=Newsletter%20Subscription&body=Please%20subscribe%20me%20with%20this%20email:%20${encodeURIComponent(

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -44,7 +44,7 @@ export default function Navbar(){
         <a href="/map/monasteries" aria-label="Map">MAP</a>
         <a href="/guidesAndHotels" aria-label="Guides and Hotels">GUIDES & HOTELS</a>
         <a href="#" aria-label="Festivals and Events">FESTIVALS & EVENTS</a>
-        <a href="#" aria-label="News">NEWS</a>
+        <a href="/news" aria-label="News">NEWS</a>
       </div>
       <div className='mr-10'>
          LOGIN/SIGNUP

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "leaflet": "^1.9.4",
         "lucide-react": "^0.544.0",
         "next": "15.5.2",
+        "nodemailer": "^7.0.6",
         "react": "^19.0.0-rc.1",
         "react-dom": "^19.0.0-rc.1",
         "react-leaflet": "^5.0.0-rc.2",
@@ -1760,6 +1761,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.544.0",
     "next": "15.5.2",
+    "nodemailer": "^7.0.6",
     "react": "^19.0.0-rc.1",
     "react-dom": "^19.0.0-rc.1",
     "react-leaflet": "^5.0.0-rc.2",


### PR DESCRIPTION
## Purpose

The user wanted to implement a newsletter subscription feature accessible from the news navigation link. When users enter their email and subscribe, the system should forward the subscription information to a designated email address without requiring a database. The user requested guidance on where to configure email credentials and variables for the email forwarding functionality.

## Code changes

- **Added newsletter API endpoint** (`app/api/newsletter/route.ts`): Created a POST endpoint that validates email addresses, configures SMTP transport using environment variables, and sends subscription notifications to a designated email address
- **Created news page** (`app/news/page.tsx`): Built a responsive newsletter subscription form with email validation, loading states, and user feedback messages
- **Updated navigation** (`components/navbar.tsx`): Changed the NEWS link from a placeholder (`#`) to point to the new `/news` page
- **Added nodemailer dependency** (`package.json`): Installed nodemailer package for email functionality

The implementation uses environment variables for email configuration (SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, FROM_EMAIL, TO_EMAIL, SMTP_SECURE) and forwards subscription details to the specified recipient email without requiring database storage.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7025913b070648658d3d4ec63ebf464c/nova-haven)

👀 [Preview Link](https://7025913b070648658d3d4ec63ebf464c-nova-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7025913b070648658d3d4ec63ebf464c</projectId>-->
<!--<branchName>nova-haven</branchName>-->